### PR TITLE
Api returns different interface

### DIFF
--- a/src/ForgeClient.ts
+++ b/src/ForgeClient.ts
@@ -9,7 +9,7 @@ export interface ForgeClientSettings {
 export interface Quote {
   bid: number;
   ask: number;
-  float: number;
+  price: number;
   symbol: string;
   timestamp: number;
 }


### PR DESCRIPTION
Api returns different interface. `Price` instead `float`